### PR TITLE
Huge reformat update

### DIFF
--- a/bingo-templates/botw.json
+++ b/bingo-templates/botw.json
@@ -1,164 +1,162 @@
 [
     [
-        {"name": "Obtain 3 Koroks on the Plateau", "types": ["Plateau", "Center", "Inventory", "Korok", "Weapon", "Shield", "Bow", "Beginning Story"] },
-        {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Beginning Story", "Armor"] },
-        {"name": "Complete the 'Watch Out for the Flowers' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "West Necluda", "Necluda", "East"] },
-        {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Center", "Inventory", "Beginning Story"] }
+        {"name": "Obtain 3 Koroks on the Plateau", "types": ["Plateau", "Korok"] },
+        {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Armor"] },
+        {"name": "Complete the 'Watch Out for the Flowers' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Dueling Peaks"] },
+        {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Monster"] }
     ],
     [
-		{"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss"] },
-        {"name": "Kill a Wizzrobe", "types": ["Miniboss"]},
-        {"name": "Activate the Dueling Peaks Tower", "types": ["West Necluda", "Necluda", "East", "Beginning Story", "Tower"] },
-        {"name": "Activate the Faron Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Tower"] }
+		{"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss", "Monster"] },
+        {"name": "Kill a Wizzrobe", "types": ["Miniboss", "Monster"]},
+        {"name": "Activate the Dueling Peaks Tower", "types": ["Dueling Peaks", "Tower"] },
+        {"name": "Activate the Faron Tower", "types": ["Lake Hylia", "Faron", "Tower"] }
     ],
     [
-        {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko", "Necluda", "Side Quest"]},
-        {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss"] },
-        {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
-        {"name": "Pay 1 Great Fairy", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] }
+        {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko",  "Side Quest"]},
+        {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss", "Monster"] },
+        {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine"] },
+        {"name": "Pay 1 Great Fairy", "types": ["Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] },
     ],
     [
-        {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "West Necluda", "Kakariko", "Side Quest"] },
-        {"name": "Obtain part of the Climbing Gear set", "types": ["Shrine","Armor"] },
-        {"name": "Collect 5 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] },
-        {"name": "Activate the Lake Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Tower"] },
-        {"name": "Activate the Hateno Tower", "types": ["East Necluda", "East", "Hateno", "Beginning Story", "Tower"] }
+        {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "Dueling Peaks", "Kakariko", "Side Quest"] },
+        {"name": "Obtain part of the Climbing Gear set", "types": ["Dueling Peaks", "Shrine", "Armor"] },
+        {"name": "Activate the Lake Tower", "types": ["Lake", "Tower"] },
+        {"name": "Activate the Hateno Tower", "types": ["Hateno", "Tower"] }
     ],
     [
-        {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
-        {"name": "Activate the Lanayru Tower", "types": ["Zora's Domain", "Lanayru", "East", "Story", "Tower"] },
-        {"name": "Activate the Wasteland Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
-        {"name": "Activate the Ridgeland Tower", "types": ["Center", "West", "Tower"] },
+        {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Lanayru"] },
+        {"name": "Activate the Lanayru Tower", "types": ["Lanayru", "Tower"] },
+        {"name": "Activate the Wasteland Tower", "types": ["Wasteland", "Tower"] },
+        {"name": "Activate the Ridgeland Tower", "types": ["Center", "Tower"] },
         {"name": "Activate the Central Tower", "types": ["Center", "Central Hyrule", "Tower"] }
     ],
     [
-        {"name": "Activate the Woodland Tower", "types": ["Korok Forest", "North", "Tower"] },
-        {"name": "Activate the Gerudo Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
-        {"name": "Activate the Akkala Tower", "types": ["North", "East", "Tower"] },
-        {"name": "Talk to Kilton", "types": ["North", "East", "Monster Part"] },
-        {"name": "Activate the Eldin Tower", "types": ["North", "East", "Tower", "Story", "Death Mountain"] },
+        {"name": "Activate the Woodland Tower", "types": ["Woodland", "Tower"] },
+        {"name": "Activate the Gerudo Tower", "types": ["Gerudo", "Tower"] },
+        {"name": "Activate the Akkala Tower", "types": ["Akkala", "Tower"] },
+        {"name": "Talk to Kilton", "types": ["Akkala", "Monster"] },
+        {"name": "Activate the Eldin Tower", "types": [ "Eldin", "Tower", "Death Mountain"] },
         {"name": "Collect 2000 Rupees", "types": ["Rupee"] },
-        {"name": "Get the Champion's Tunic", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Beginning Story", "Story"] }
+        {"name": "Get the Champion's Tunic", "types": ["Kakariko", "Memory", "Story"] }
     ],
     [
-        {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
-        {"name": "Find 5 Koroks in the Dueling Peaks Tower region", "types": ["Korok", "Dueling Peaks", "West Necluda", "Necluda", "East"] },
-        {"name": "Find 5 Koroks in the Faron Tower Region", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Korok"] },
-        {"name": "Complete the 'Song of Storms' Shrine Quest", "types": ["Shrine Quest", "South", "Faron", "East Necluda", "Shrine", "Heart", "Stamina", "Thunder"] },
-        {"name": "Activate the Hebra Tower", "types": ["North", "West", "Tower", "Story", "Hebra"] }
+        {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Lanayru"] },
+        {"name": "Find 5 Koroks in the Dueling Peaks Tower region", "types": ["Korok", "Dueling Peaks"] },
+        {"name": "Find 5 Koroks in the Faron Tower Region", "types": ["Faron", "Korok"] },
+        {"name": "Complete the 'Song of Storms' Shrine Quest", "types": ["Shrine Quest", "Faron", "Shrine", "Thunder"] },
+        {"name": "Activate the Hebra Tower", "types": [ "Tower", "Hebra", "Cold Resistance"] }
     ],
     [
-        {"name": "Complete 'The Gut Check Challenge' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Eldin", "North", "East"] },
-        {"name": "Complete the Forgotten Temple's Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Hebra", "North", "West"] },
-        {"name": "Complete the 'Twin Memories' shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "West Necluda", "Necluda", "East"] },
-        {"name": "Find 5 Koroks in the Lake Tower Region", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Korok"] },
-        {"name": "Find 5 Koroks in the Hateno Tower Region", "types": ["East Necluda", "East", "Hateno", "Korok"] },
-        {"name": "Pay 2 Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] }
+        {"name": "Complete 'The Gut Check Challenge' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Eldin", "Stamina"] },
+        {"name": "Complete the Forgotten Temple's Shrine", "types": ["Shrine", "Hebra"] },
+        {"name": "Complete the 'Twin Memories' shrines", "types": ["Shrine", "Dueling Peaks"] },
+        {"name": "Find 5 Koroks in the Lake Tower Region", "types": ["Lake", "Korok"] },
+        {"name": "Find 5 Koroks in the Hateno Tower Region", "types": ["Hateno", "Korok"] },
+        {"name": "Pay 2 Great Fairies", "types": ["Dueling Peaks", "Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] }
     ],
     [
-        {"name": "Complete the 'Shrouded Shrine' Shrine Quest", "types": ["Shrine", "Shrine Quest", "North", "Soul Orb", "Heart", "Stamina"] },
-        {"name": "Find 5 Koroks in the Lanayru Tower Region", "types": ["Zora's Domain", "Lanayru", "East", "Korok"] },
-        {"name": "Find 5 Koroks in the Wasteland Tower Region", "types": ["Gerudo", "South", "West", "Korok"] },
-        {"name": "Find 5 Koroks in the Ridgeland Tower Region", "types": ["Center", "West", "Korok"] },
-        {"name": "Get the Sheikah Set", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Armor", "Rupee", "Stealth"] },
-        {"name": "Get the Soldier Set", "types": ["Hateno", "Necluda", "East", "East Necluda", "Armor", "Rupee"] }
+        {"name": "Complete the 'Shrouded Shrine' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Woodland"] },
+        {"name": "Find 5 Koroks in the Lanayru Tower Region", "types": ["Lanayru", "Korok"] },
+        {"name": "Find 5 Koroks in the Wasteland Tower Region", "types": ["Wasteland", "Korok"] },
+        {"name": "Find 5 Koroks in the Ridgeland Tower Region", "types": ["Ridgeland", "Korok"] },
+        {"name": "Get the Sheikah Set", "types": ["Kakariko", "Armor", "Rupee", "Stealth"] },
+        {"name": "Get the Soldier Set", "types": ["Hateno", "Armor", "Rupee"] }
     ],
     [
         {"name": "Find 5 Koroks in the Central Tower Region", "types": ["Center", "Central Hyrule", "Korok"] },
-        {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Korok Forest", "North", "Korok"] },
-        {"name": "Find 5 Koroks in the Gerudo Tower Region", "types": ["Gerudo", "South", "West", "Korok"] },
-        {"name": "Read Zelda's Diary", "types": ["Central Hyrule", "Hyrule Castle", "North", "Story"] },
-        {"name": "Bake an Apple Pie", "types": ["Rupee","West"] },
-        {"name": "Obtain the Hylian Shield", "types": ["Central Hyrule", "Hyrule Castle", "North"] }
+        {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Korok Forest", "Korok"] },
+        {"name": "Find 5 Koroks in the Gerudo Tower Region", "types": ["Gerudo", "Korok"] },
+        {"name": "Read Zelda's Diary", "types": ["Central", "Hyrule Castle", "Story"] },
+        {"name": "Bake an Apple Pie", "types": ["Cooking", "Tabantha"] },
+        {"name": "Obtain the Hylian Shield", "types": ["Central", "Hyrule Castle", "Hinox", "Monster"] }
     ],
     [
-        {"name": "Find 5 Koroks in the Akkala Tower Region", "types": ["North", "East", "Korok"] },
-        {"name": "Find 5 Koroks in the Eldin Tower Region", "types": ["North", "East", "Korok", "Death Mountain"] },
-        {"name": "Find 5 Koroks in the Hebra Tower Region", "types": ["North", "West", "Korok", "Hebra"] },
-        {"name": "Complete the Vortex Shrine Quest", "types": ["East", "South", "South East", "Faron", "Necluda", "Shrine", "Shrine Quest"] },
-        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Shrine Quest", "South", "East", "South East", "Shrine", "Heart", "Stamina", "Ancient Item"] },
-        {"name": "Register the Royal Horse", "types": ["Center", "Central Hyrule", "Horse", "Stamina"] }
+        {"name": "Find 5 Koroks in the Akkala Tower Region", "types": ["Akkala", "Korok"] },
+        {"name": "Find 5 Koroks in the Eldin Tower Region", "types": ["Eldin", "Korok"] },
+        {"name": "Find 5 Koroks in the Hebra Tower Region", "types": ["Korok", "Hebra", "Cold Resistance"] },
+        {"name": "Complete the Vortex Shrine Quest", "types": ["Akkala", "Shrine", "Shrine Quest"] },
+        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Faron", "Shrine Quest", "Shrine"] },
+        {"name": "Register the Royal Horse", "types": ["Centeral", "Central Hyrule", "Horse", "Stamina"] }
     ],
     [
-		{"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "East Necluda", "Hateno", "Heart", "Stamina"] },
-        {"name": "Kill a Walking Guardian", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] },
-        {"name": "Complete 5 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
-        {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["East", "South", "South East", "Faron", "Necluda", "Shrine", "Shrine Quest"] }
+		{"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "Hateno", "Heart", "Stamina"] },
+        {"name": "Kill a Walking Guardian", "types": ["Central", "Hyrule Castle", "Guardian"] },
+        {"name": "Complete 5 Shrines", "types": ["Shrine"] },
+        {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["Faron", "Hinox", "Monster", "Shrine", "Shrine Quest"] }
     ],
     [
-        {"name": "Collect 2 Memories", "types": ["Memory", "Story"] },
-        {"name": "Obtain a Material from Naydra", "types": ["Necluda", "Mount Lanayru", "East Necluda", "East"] },
-        {"name": "Take a Selfie with Sidon", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story", "Camera", "Hateno", "Beginning Story"] },
-        {"name": "Finish a Korok Trial", "types": ["Korok Forest", "North", "Shrine", "Soul Orb", "Heart", "Stamina"] }
+        {"name": "Collect 2 Memories", "types": ["Hateno", "Memory", "Story"] },
+        {"name": "Obtain a Material from Naydra", "types": ["Mount Lanayru", "Hateno"] },
+        {"name": "Take a Selfie with Sidon", "types": ["Lanayru", "Zora's Domain", "Story", "Camera", "Hateno"] },
+        {"name": "Finish a Korok Trial", "types": ["Woodland", "Korok Forest", "Shrine"] }
     ],
     [
-        {"name": "Complete the 'Guardian Slideshow' Shrine Quest", "types": ["Shrine Quest", "South", "Shrine", "Heart", "Stamina", "Camera"] },
-        {"name": "Obtain a Material from Farosh", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East"] },
-        {"name": "Obtain a Material from Dinraal", "types": ["North", "West", "North West"] },
-        {"name": "Complete a Modest Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
+        {"name": "Complete the 'Guardian Slideshow' Shrine Quest", "types": ["Shrine Quest", "Shrine", "Camera"] },
+        {"name": "Obtain a Material from Farosh", "types": ["Lake", "Gerudo", "Faron"] },
+        {"name": "Obtain a Material from Dinraal", "types": ["Eldin", "Woodland", "Ridgeland"] },
+        {"name": "Complete a Modest Test of Strength Shrine", "types": ["Shrine", "Guardian"] }
     ],
     [
-        {"name": "Complete the Shield Surfing minigame", "types": ["Minigame", "North", "West", "Hebra"] },
-        {"name": "Complete the Bowling minigame", "types": ["Minigame", "North", "West", "Hebra"] },
+        {"name": "Complete the Shield Surfing minigame", "types": ["Minigame", "Hebra", "Cold Resistance"] },
+        {"name": "Complete the Bowling minigame", "types": ["Minigame", "Hebra", "Cold Resistance"] },
         {"name": "Activate 4 Towers", "types": ["Tower"] },
-        {"name": "Collect 20 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] }
+        {"name": "Collect 20 Korok Seeds", "types": ["Inventory", "Korok"] }
     ],
     [
 		{"name": "Complete the 'Robbie's Research' Side Quest", "types": ["Side Quest", "Akkala", "Hateno"] },
-        {"name": "Upgrade All Runes", "types": ["Side Quest", "Upgrade", "Ancient Item", "Beginning Story", "Necluda", "East Necluda", "Hateno", "East"] },
-        {"name": "Register the Giant Horse", "types": ["South", "West", "South West", "Horse", "Stamina"] },
-        {"name": "Get the Zora Set", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story"] },
-        {"name": "Get the Flamebreaker Set", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Heart", "North", "East", "Story", "Armor", "Rupee", "Fire Resistance"] }
+        {"name": "Upgrade All Runes", "types": ["Side Quest", "Upgrade", "Beginning Story", "Hateno"] },
+        {"name": "Register the Giant Horse", "types": [  "South West", "Horse", "Stamina"] },
+        {"name": "Get the Zora Set", "types": ["Lanayru", "Zora's Domain", "Armor", "Story"] },
+        {"name": "Get the Flamebreaker Set", "types": ["Eldin", "Story", "Armor", "Rupee", "Fire Resistance"] }
     ],
     [
-        {"name": "Mount the Lord of the Mountain", "types": ["Center", "Central Hyrule", "Horse", "Stamina"] },
-        {"name": "Get the Barbarian Set", "types": ["Shrine", "Hebra", "North", "East", "West", "South", "North East", "North West", "South West", "Armor", "Akkala", "Gerudo"] },
-        {"name": "Obtain 3 Heart Containers", "types": ["Shrine", "Soul Orb", "Heart", "Divine Beast"] },
-        {"name": "Get the Rubber Set", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story"] }
+        {"name": "Mount the Lord of the Mountain", "types": ["Central", "Horse", "Stamina"] },
+        {"name": "Get the Barbarian Set", "types": ["Shrine", "Hebra", "Cold Resistance", "Armor", "Akkala", "Gerudo"] },
+        {"name": "Obtain 3 Heart Containers", "types": ["Shrine", "Soul Orb", "Heart"] },
+        {"name": "Get the Rubber Set", "types": ["Ridgeland", "Faron", "Armor", "Side Quest", "Shrine Quest"] }
     ],
     [
-        {"name": "Complete 'Little Sister's Big Request' Side Quest", "types": ["Akkala", "Eldin", "Side Quest"] },
-        {"name": "Complete the 'Fragmented Monument' Shrine Quest", "types": ["Shrine Quest", "South", "Faron", "East Necluda", "Shrine", "Heart", "Stamina", "Thunder"] },
-        {"name": "Complete 'Rushroom Rush' Side Quest", "types": ["Gerudo", "South", "West", "Rushroom", "Side Quest"] },
-        {"name": "Complete 10 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
+        {"name": "Complete 'Little Sister's Big Request' Side Quest", "types": ["Akkala", "Side Quest"] },
+        {"name": "Complete the 'Fragmented Monument' Shrine Quest", "types": ["Shrine Quest",  "Faron",  "Shrine",  "Thunder"] },
+        {"name": "Complete 'Rushroom Rush' Side Quest", "types": ["Wasteland", "Stamina", "Side Quest"] },
+        {"name": "Complete 10 Shrines", "types": ["Shrine", "Ancient Item"] }
     ],
     [
-		{"name": "Complete 'The Stolen Heirloom' Shrine Quest", "types": ["Shrine Quest", "West Necluda", "Kakariko", "Shrine"] },
+		{"name": "Complete 'The Stolen Heirloom' Shrine Quest", "types": ["Dueling Peaks", "Shrine Quest", "Kakariko", "Shrine"] },
         {"name": "Collect 4 Memories", "types": ["Memory", "Story"] },
         {"name": "Fill out 20 creatures in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Complete 3 Side Quests", "types": ["Side Quest"] },
-        {"name": "Kill Coliseum Lynel", "types": ["Center", "Central Hyrule", "Coliseum", "Lynel", "Miniboss"] }
+        {"name": "Kill Coliseum Lynel", "types": ["Central", "Miniboss", "Monster"] }
     ],
     [
-        {"name": "Complete 'Leviathan Bones' Side Quest", "types": ["Gerudo", "Hebra", "Eldin", "Camera", "Side Quest"] },
+        {"name": "Complete 'Leviathan Bones' Side Quest", "types": ["Wasteland", "Hebra", "Cold Resistance", "Eldin", "Camera", "Side Quest"] },
         {"name": "Fill out 20 monsters in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Fill out 20 equipment in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Complete 5 Side Quests", "types": ["Side Quest"] },
-        {"name": "Complete a Major Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
+        {"name": "Complete a Major Test of Strength Shrine", "types": ["Shrine", "Guardian"] }
     ],
     [
         {"name": "Buy the Bokoblin Mask from Kilton", "types": ["Monster Part"] },
-        {"name": "Complete 15 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
-        {"name": "Kill 10 Guardians", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] }
+        {"name": "Complete 15 Shrines", "types": ["Shrine", "Ancient Item"] },
+        {"name": "Kill 10 Guardians", "types": ["Central", "Hyrule Castle", "Guardian"] }
     ],
     [
-        {"name": "Pay 3 Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
+        {"name": "Pay 3 Great Fairies", "types": ["Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] },
         {"name": "Free a Divine Beast", "types": ["Divine Beast", "Story", "Heart"] }
     ],
     [
-        {"name": "Free Vah Medoh", "types": ["Rito", "Divine Beast", "Vah Medoh", "Heart", "North", "West", "North West", "Story", "Armor", "Cold Resistance", "Hebra"] },
-        {"name": "Free Vah Ruta", "types": ["Zora's Domain", "Lanayru", "Divine Beast", "Vah Ruta", "Heart", "East", "Story", "Armor", "Swim Speed", "Arrow"] }
+        {"name": "Free Vah Medoh", "types": ["Tabantha", "Divine Beast", "Vah Medoh", "Story", "Armor", "Hebra", "Cold Resistance"] },
+        {"name": "Free Vah Ruta", "types": ["Zora's Domain", "Lanayru", "Divine Beast", "Vah Ruta", "Heart",  "Story", "Armor", "Swim Speed"] }
     ],
     [
-        {"name": "Free Vah Rudania", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Heart", "North", "East", "Story", "Armor", "Fire Resistance"] },
-        {"name": "Free Vah Naboris", "types": ["Gerudo", "Divine Beast", "Vah Naboris", "Heart", "South", "West", "South West", "Story", "Armor", "Heat Resistance", "Banana", "Yiga"] },
-        {"name": "Kill 20 Walking Guardians", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] },
+        {"name": "Free Vah Rudania", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Story", "Armor", "Fire Resistance"] },
+        {"name": "Free Vah Naboris", "types": ["Wasteland", "Divine Beast", "Vah Naboris", "Story", "Heat Resistance", "Yiga"] },
         {"name": "Activate all Towers", "types": ["Tower"] }
     ],
     [
         {"name": "Complete 10 Side Quests", "types": ["Side Quest"] },
-        {"name": "Pay all Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
-        {"name": "Get the Master Sword", "types": ["Korok Forest", "North", "Heart"] },
-        {"name": "Beat Ganon", "types": ["Hyrule Castle", "Ganon", "North"] }
+        {"name": "Pay all Great Fairies", "types": ["Akkala", "Gerudo", "Rito", "Rupee", "Great Fairy"] },
+        {"name": "Get the Master Sword", "types": ["Woodland", "Korok Forest", "Heart"] },
+        {"name": "Beat Ganon", "types": ["Central","Hyrule Castle", "Ganon"] }
     ]
 ]

--- a/bingo-templates/botw.json
+++ b/bingo-templates/botw.json
@@ -1,38 +1,37 @@
 [
     [
         {"name": "Obtain 3 Koroks on the Plateau", "types": ["Plateau", "Center", "Inventory", "Korok", "Weapon", "Shield", "Bow", "Beginning Story"] },
-        {"name": "Open a Bokoblin Camp Chest", "types": ["Plateau", "Center", "Inventory", "Beginning Story"] },
-        {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Beginning Story", "Armor"] }
-    ],
-    [
+        {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Beginning Story", "Armor"] },
         {"name": "Complete the 'Watch Out for the Flowers' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "West Necluda", "Necluda", "East"] },
         {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Center", "Inventory", "Beginning Story"] }
     ],
     [
-        {"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss"] },
-        {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
+		{"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss"] },
+        {"name": "Kill a Wizzrobe", "types": ["Miniboss"]},
         {"name": "Activate the Dueling Peaks Tower", "types": ["West Necluda", "Necluda", "East", "Beginning Story", "Tower"] },
         {"name": "Activate the Faron Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Tower"] }
     ],
     [
-        {"name": "Pay 1 Great Fairy", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
-        {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] }
-    ],
-    [
-        {"name": "Obtain 2 Koroks in the Hateno Region", "types": ["East Necluda", "East", "Hateno", "Inventory", "Korok", "Weapon", "Shield", "Bow", "Beginning Story"] },
-        {"name": "Collect 5 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] },
-        {"name": "Activate the Lake Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Tower"] },
-        {"name": "Activate the Hateno Tower", "types": ["East Necluda", "East", "Hateno", "Beginning Story", "Tower"] },
-        {"name": "Activate the Lanayru Tower", "types": ["Zora's Domain", "Lanayru", "East", "Story", "Tower"] },
-        {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Beginning Story", "Story",]},
-        {"name": "Activate the Wasteland Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
-        {"name": "Activate the Ridgeland Tower", "types": ["Center", "West", "Tower"] },
-        {"name": "Activate the Central Tower", "types": ["Center", "Central Hyrule", "Tower"] },
-        {"name": "Kill a Wizzrobe", "types": []},
-        {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
+        {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko", "Necluda", "Side Quest"]},
+        {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss"] },
+        {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
+        {"name": "Pay 1 Great Fairy", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] }
     ],
     [
         {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "West Necluda", "Kakariko", "Side Quest"] },
+        {"name": "Obtain part of the Climbing Gear set", "types": ["Shrine","Armor"] },
+        {"name": "Collect 5 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] },
+        {"name": "Activate the Lake Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Tower"] },
+        {"name": "Activate the Hateno Tower", "types": ["East Necluda", "East", "Hateno", "Beginning Story", "Tower"] }
+    ],
+    [
+        {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
+        {"name": "Activate the Lanayru Tower", "types": ["Zora's Domain", "Lanayru", "East", "Story", "Tower"] },
+        {"name": "Activate the Wasteland Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
+        {"name": "Activate the Ridgeland Tower", "types": ["Center", "West", "Tower"] },
+        {"name": "Activate the Central Tower", "types": ["Center", "Central Hyrule", "Tower"] }
+    ],
+    [
         {"name": "Activate the Woodland Tower", "types": ["Korok Forest", "North", "Tower"] },
         {"name": "Activate the Gerudo Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
         {"name": "Activate the Akkala Tower", "types": ["North", "East", "Tower"] },
@@ -42,10 +41,10 @@
         {"name": "Get the Champion's Tunic", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Beginning Story", "Story"] }
     ],
     [
+        {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
         {"name": "Find 5 Koroks in the Dueling Peaks Tower region", "types": ["Korok", "Dueling Peaks", "West Necluda", "Necluda", "East"] },
         {"name": "Find 5 Koroks in the Faron Tower Region", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Korok"] },
         {"name": "Complete the 'Song of Storms' Shrine Quest", "types": ["Shrine Quest", "South", "Faron", "East Necluda", "Shrine", "Heart", "Stamina", "Thunder"] },
-        {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss"] },
         {"name": "Activate the Hebra Tower", "types": ["North", "West", "Tower", "Story", "Hebra"] }
     ],
     [
@@ -69,7 +68,7 @@
         {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Korok Forest", "North", "Korok"] },
         {"name": "Find 5 Koroks in the Gerudo Tower Region", "types": ["Gerudo", "South", "West", "Korok"] },
         {"name": "Read Zelda's Diary", "types": ["Central Hyrule", "Hyrule Castle", "North", "Story"] },
-        {"name": "Bake an Apple Pie", "types": ["Rupee"] },
+        {"name": "Bake an Apple Pie", "types": ["Rupee","West"] },
         {"name": "Obtain the Hylian Shield", "types": ["Central Hyrule", "Hyrule Castle", "North"] }
     ],
     [

--- a/bingo-templates/botw.json
+++ b/bingo-templates/botw.json
@@ -2,17 +2,20 @@
     [
         {"name": "Obtain 3 Koroks on the Plateau", "types": ["Plateau", "Korok"] },
         {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Armor"] },
+        {"name": "Give Beedle a Beetle", "types": ["Stable"] },
+        {"name": "Register a Horse", "types": ["Stable"] },
         {"name": "Complete the 'Watch Out for the Flowers' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Dueling Peaks"] },
-        {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Monster"] }
+        {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Monster"] },
+        {"name": "Save a Traveler in Peril", "types": ["Monster"] }
     ],
     [
-		{"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss", "Monster"] },
+        {"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss", "Monster"] },
         {"name": "Kill a Wizzrobe", "types": ["Miniboss", "Monster"]},
         {"name": "Cook a Hearty meal", "types": ["Cooking", "Hearts"] },
         {"name": "Cook a Hasty meal", "types": ["Cooking", "Speed"] },
         {"name": "Cook a Spicy meal", "types": ["Cooking", "Cold Resistance"] },
         {"name": "Activate the Dueling Peaks Tower", "types": ["Dueling Peaks", "Tower"] },
-		{"name": "Complete 'The Two Rings' Shrine Quest","types":["Ridgeland", "Shrine Quest"]}
+        {"name": "Complete 'The Two Rings' Shrine Quest","types":["Ridgeland", "Shrine Quest"]}
     ],
     [
         {"name": "Cook a Mighty meal", "types": ["Cooking", "Attack"] },
@@ -28,19 +31,21 @@
         {"name": "Cook an Energizing meal", "types": ["Cooking", "Stamina"] },
         {"name": "Complete the 'Cliffside Etchings' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Gerudo"] },
         {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "Dueling Peaks", "Kakariko", "Side Quest"] },
-        {"name": "Obtain part of the Climbing Gear set", "types": ["Dueling Peaks", "Shrine", "Armor"] },
         {"name": "Activate the Lake Tower", "types": ["Lake", "Tower"] },
         {"name": "Activate the Hateno Tower", "types": ["Hateno", "Tower"] }
     ],
     [
-		{"name": "Complete 'The Cursed Statue' Shrine Quest","types":["Hateno", "Shrine Quest"]},
+        {"name": "Complete 3 Shrines in the Dueling Peaks Tower region", "types": ["Shrine", "Dueling Peaks"] },
+        {"name": "Complete 'The Cursed Statue' Shrine Quest","types":["Hateno", "Shrine Quest"]},
         {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Lanayru"] },
+        {"name": "Get 500m in the Gliding minigame", "types": ["Minigame", "Ridgeland"] },
         {"name": "Activate the Lanayru Tower", "types": ["Lanayru", "Tower"] },
         {"name": "Activate the Wasteland Tower", "types": ["Wasteland", "Tower"] },
         {"name": "Activate the Ridgeland Tower", "types": ["Center", "Tower"] },
         {"name": "Activate the Central Tower", "types": ["Center", "Central Hyrule", "Tower"] }
     ],
     [
+        {"name": "Complete 3 Shrines in the Central Tower Region", "types": ["Central", "Shrine"] },
         {"name": "Activate the Woodland Tower", "types": ["Woodland", "Tower"] },
         {"name": "Activate the Gerudo Tower", "types": ["Gerudo", "Tower"] },
         {"name": "Activate the Akkala Tower", "types": ["Akkala", "Tower"] },
@@ -50,13 +55,17 @@
         {"name": "Get the Champion's Tunic", "types": ["Kakariko", "Memory", "Story"] }
     ],
     [
+        {"name": "Complete 3 Shrines in the Lake Tower Region", "types": ["Lake", "Shrine"] },
         {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Lanayru"] },
         {"name": "Find 5 Koroks in the Dueling Peaks Tower region", "types": ["Korok", "Dueling Peaks"] },
         {"name": "Find 5 Koroks in the Faron Tower Region", "types": ["Faron", "Korok"] },
         {"name": "Complete the 'Song of Storms' Shrine Quest", "types": ["Shrine Quest", "Faron", "Shrine", "Thunder"] },
-        {"name": "Activate the Hebra Tower", "types": [ "Tower", "Hebra", "Cold Resistance"] }
+        {"name": "Activate the Hebra Tower", "types": [ "Tower", "Hebra", "Cold Resistance"] },
+        {"name": "Activate the Tabantha Tower", "types": [ "Tower", "Tabantha"] },
+        {"name": "Upgrade the Hylian set", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] }
     ],
     [
+        {"name": "Complete 3 Shrines in the Akkala Tower Region", "types": ["Akkala", "Shrine"] },
         {"name": "Complete 'The Gut Check Challenge' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Eldin", "Stamina"] },
         {"name": "Complete the Forgotten Temple's Shrine", "types": ["Shrine", "Hebra"] },
         {"name": "Complete the 'Twin Memories' shrines", "types": ["Shrine", "Dueling Peaks"] },
@@ -65,77 +74,96 @@
         {"name": "Pay 2 Great Fairies", "types": ["Dueling Peaks", "Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] }
     ],
     [
+        {"name": "Complete 3 Shrines in the Ridgeland Tower Region", "types": ["Ridgeland", "Shrine"] },
+        {"name": "Complete 3 Shrines in the Hateno Tower Region", "types": ["Hateno", "Shrine"] },
         {"name": "Complete the 'Shrouded Shrine' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Woodland"] },
         {"name": "Find 5 Koroks in the Lanayru Tower Region", "types": ["Lanayru", "Korok"] },
         {"name": "Find 5 Koroks in the Wasteland Tower Region", "types": ["Wasteland", "Korok"] },
         {"name": "Find 5 Koroks in the Ridgeland Tower Region", "types": ["Ridgeland", "Korok"] },
-        {"name": "Get the Sheikah Set", "types": ["Kakariko", "Armor", "Rupee", "Stealth"] },
+        {"name": "Get the Stealth Set", "types": ["Kakariko", "Armor", "Rupee", "Stealth"] },
         {"name": "Get the Soldier Set", "types": ["Hateno", "Armor", "Rupee"] }
     ],
     [
-        {"name": "Find 5 Koroks in the Central Tower Region", "types": ["Center", "Central Hyrule", "Korok"] },
-        {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Korok Forest", "Korok"] },
+        {"name": "Complete 3 Shrines in the Wasteland Tower Region", "types": ["Wasteland", "Shrine"] },
+        {"name": "Complete 3 Shrines in the Woodland Tower Region", "types": ["Woodland", "Korok Forest", "Shrine"] },
+        {"name": "Find 5 Koroks in the Central Tower Region", "types": ["Central", "Korok"] },
+        {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Woodland", "Korok"] },
         {"name": "Find 5 Koroks in the Gerudo Tower Region", "types": ["Gerudo", "Korok"] },
         {"name": "Read Zelda's Diary", "types": ["Central", "Hyrule Castle", "Story"] },
         {"name": "Bake an Apple Pie", "types": ["Cooking", "Tabantha"] },
         {"name": "Obtain the Hylian Shield", "types": ["Central", "Hyrule Castle", "Hinox", "Monster"] }
     ],
     [
+        {"name": "Complete 3 Shrines in the Tabantha Tower Region", "types": ["Tabantha", "Shrine"] },
         {"name": "Find 5 Koroks in the Akkala Tower Region", "types": ["Akkala", "Korok"] },
         {"name": "Find 5 Koroks in the Eldin Tower Region", "types": ["Eldin", "Korok"] },
+        {"name": "Find 5 Koroks in the Tabantha Tower Region", "types": ["Tabantha", "Korok"] },
         {"name": "Find 5 Koroks in the Hebra Tower Region", "types": ["Korok", "Hebra", "Cold Resistance"] },
         {"name": "Complete the Vortex Shrine Quest", "types": ["Akkala", "Shrine", "Shrine Quest"] },
-        {"name": "Register the Royal Horse", "types": ["Centeral", "Central Hyrule", "Horse", "Stamina"] }
+        {"name": "Upgrade the Soldier's set", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] },
+        {"name": "Register the Royal Horse", "types": ["Central", "Stable", "Stamina"] }
     ],
     [
-		{"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "Hateno", "Heart", "Stamina"] },
+        {"name": "Complete 3 Shrines in the Eldin Tower Region", "types": ["Eldin", "Shrine", "Fire Resistance"] },
+        {"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "Hateno", "Heart", "Stamina"] },
         {"name": "Kill a Walking Guardian", "types": ["Central", "Hyrule Castle", "Guardian"] },
-        {"name": "Complete 5 Shrines", "types": ["Shrine"] },
         {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["Faron", "Hinox", "Monster", "Shrine", "Shrine Quest"] },
-        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Faron", "Shrine Quest", "Shrine"] }
+        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Faron", "Shrine Quest", "Shrine"] },
+        {"name": "Complete a Major Test of Strength Shrine", "types": ["Shrine", "Guardian"] }
     ],
-    [
+    [    
+        {"name": "Complete 3 Shrines in the Gerudo Tower Region", "types": ["Gerudo", "Shrine", "Cold Resistance"] },
+        {"name": "Complete 3 Shrines in the Hebra Tower Region", "types": ["Shrine", "Hebra", "Cold Resistance"] },
         {"name": "Collect 2 Memories", "types": ["Hateno", "Memory", "Story"] },
         {"name": "Obtain a Material from Naydra", "types": ["Mount Lanayru", "Hateno"] },
+        {"name": "Kill a Lynel", "types": ["Miniboss", "Monster"] },
         {"name": "Take a Selfie with Sidon", "types": ["Lanayru", "Zora's Domain", "Story", "Camera", "Hateno"] },
         {"name": "Finish a Korok Trial", "types": ["Woodland", "Korok Forest", "Shrine"] }
     ],
     [
-        {"name": "Complete the 'Guardian Slideshow' Shrine Quest", "types": ["Shrine Quest", "Shrine", "Camera"] },
+        {"name": "Complete the 'Guardian Slideshow' Shrine Quest", "types": ["Lake", "Shrine Quest", "Shrine", "Camera"] },
         {"name": "Obtain a Material from Farosh", "types": ["Lake", "Gerudo", "Faron"] },
         {"name": "Obtain a Material from Dinraal", "types": ["Eldin", "Woodland", "Ridgeland"] },
-        {"name": "Complete a Modest Test of Strength Shrine", "types": ["Shrine", "Guardian"] }
+        {"name": "Complete a Modest Test of Strength Shrine", "types": ["Shrine", "Guardian"] },
+        {"name": "Get the Climbing set", "types": ["Dueling Peaks", "Shrine", "Armor"] }
     ],
     [
+        {"name": "Complete the 'Brother's Roast' Shrine Quest", "types": ["Eldin", "Shrine Quest", "Shrine"] },
+        {"name": "Complete 3 Shrines in the Faron Tower Region", "types": ["Faron", "Shrine"] },
         {"name": "Complete the Shield Surfing minigame", "types": ["Minigame", "Hebra", "Cold Resistance"] },
         {"name": "Complete the Bowling minigame", "types": ["Minigame", "Hebra", "Cold Resistance"] },
         {"name": "Activate 4 Towers", "types": ["Tower"] },
-        {"name": "Collect 20 Korok Seeds", "types": ["Inventory", "Korok"] }
+        {"name": "Collect 20 Korok Seeds", "types": ["Inventory", "Korok"] },
+        {"name": "Get the Snowquill Set", "types": ["Tabantha", "Rupee", "Armor", "Cold Resistance"] }
     ],
     [
-		{"name": "Complete the 'Robbie's Research' Side Quest", "types": ["Side Quest", "Akkala", "Hateno"] },
+        {"name": "Complete the 'Robbie's Research' Side Quest", "types": ["Side Quest", "Akkala", "Hateno"] },
         {"name": "Upgrade All Runes", "types": ["Side Quest", "Upgrade", "Beginning Story", "Hateno"] },
-        {"name": "Register the Giant Horse", "types": [  "South West", "Horse", "Stamina"] },
+        {"name": "Register the Giant Horse", "types": [  "South West", "Stable", "Stamina"] },
         {"name": "Get the Zora Set", "types": ["Lanayru", "Zora's Domain", "Armor", "Story"] },
         {"name": "Get the Flamebreaker Set", "types": ["Eldin", "Story", "Armor", "Rupee", "Fire Resistance"] }
     ],
     [
-        {"name": "Mount the Lord of the Mountain", "types": ["Central", "Horse", "Stamina"] },
+        {"name": "Mount the Lord of the Mountain", "types": ["Central", "Stable", "Stamina"] },
         {"name": "Get the Barbarian Set", "types": ["Shrine", "Hebra", "Cold Resistance", "Armor", "Akkala", "Gerudo"] },
         {"name": "Obtain 3 Heart Containers", "types": ["Shrine", "Soul Orb", "Heart"] },
-        {"name": "Get the Rubber Set", "types": ["Ridgeland", "Faron", "Armor", "Side Quest", "Shrine Quest"] }
+        {"name": "Get the Rubber Set", "types": ["Ridgeland", "Faron", "Armor", "Side Quest", "Shrine Quest"] },
+        {"name": "Get the Ancient set", "types": ["Rupee", "Armor", "Ancient Item"] }
     ],
     [
         {"name": "Complete 'Little Sister's Big Request' Side Quest", "types": ["Akkala", "Side Quest"] },
         {"name": "Complete the 'Fragmented Monument' Shrine Quest", "types": ["Shrine Quest",  "Faron",  "Shrine",  "Thunder"] },
         {"name": "Complete 'Rushroom Rush' Side Quest", "types": ["Wasteland", "Stamina", "Side Quest"] },
-        {"name": "Complete 10 Shrines", "types": ["Shrine", "Ancient Item"] }
+        {"name": "Complete 10 Shrines", "types": ["Shrine", "Ancient Item"] },
+        {"name": "Pay 3 Great Fairies", "types": ["Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] },
+        {"name": "Upgrade the Stealth set", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] }
     ],
     [
-		{"name": "Complete 'The Stolen Heirloom' Shrine Quest", "types": ["Dueling Peaks", "Shrine Quest", "Kakariko", "Shrine"] },
+        {"name": "Complete 'The Stolen Heirloom' Shrine Quest", "types": ["Dueling Peaks", "Shrine Quest", "Kakariko", "Shrine"] },
         {"name": "Collect 4 Memories", "types": ["Memory", "Story"] },
         {"name": "Fill out 20 creatures in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Complete 3 Side Quests", "types": ["Side Quest"] },
+        {"name": "Upgrade the Climbing set", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] },
         {"name": "Kill Coliseum Lynel", "types": ["Central", "Miniboss", "Monster"] }
     ],
     [
@@ -143,30 +171,32 @@
         {"name": "Fill out 20 monsters in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Fill out 20 equipment in the Compendium", "types": ["Camera", "Compendium", "Story"] },
         {"name": "Complete 5 Side Quests", "types": ["Side Quest"] },
-        {"name": "Complete a Major Test of Strength Shrine", "types": ["Shrine", "Guardian"] }
+	{"name": "Upgrade the Zora Set", "types": ["Lanayru", "Zora's Domain", "Armor", "Monster", "Great Fairy"] }
     ],
     [
         {"name": "Buy the Bokoblin Mask from Kilton", "types": ["Monster Part"] },
+        {"name": "Kill 10 Guardians", "types": ["Central", "Guardian"] },
+        {"name": "Upgrade an Armor Set to Max", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] },
+        {"name": "Upgrade the Rubber set", "types": ["Rupee", "Armor", "Monster", "Great Fairy"] }
+    ],
+    [
+        {"name": "Upgrade the Snowquill Set", "types": ["Tabantha", "Rupee", "Armor", "Monster", "Great Fairy", "Cold Resistance"] },
+        {"name": "Upgrade the Flamebreaker set", "types": ["Rupee", "Armor", "Monster", "Great Fairy", "Fire Resistance" ] },
+        {"name": "Upgrade the Ancient set", "types": ["Rupee", "Armor", "Gaurdian", "Monster", "Great Fairy"] }
+    ],
+    [
         {"name": "Complete 15 Shrines", "types": ["Shrine", "Ancient Item"] },
-        {"name": "Kill 10 Guardians", "types": ["Central", "Hyrule Castle", "Guardian"] }
-    ],
-    [
-        {"name": "Pay 3 Great Fairies", "types": ["Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] },
-        {"name": "Free a Divine Beast", "types": ["Divine Beast", "Story", "Heart"] }
-    ],
-    [
         {"name": "Free Vah Medoh", "types": ["Tabantha", "Divine Beast", "Vah Medoh", "Story", "Armor", "Hebra", "Cold Resistance"] },
         {"name": "Free Vah Ruta", "types": ["Zora's Domain", "Lanayru", "Divine Beast", "Vah Ruta", "Heart",  "Story", "Armor", "Swim Speed"] }
     ],
     [
-        {"name": "Free Vah Rudania", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Story", "Armor", "Fire Resistance"] },
+        {"name": "Free Vah Rudania", "types": ["Eldin", "Death Mountain", "Divine Beast", "Vah Rudania", "Story", "Armor", "Fire Resistance"] },
         {"name": "Free Vah Naboris", "types": ["Wasteland", "Divine Beast", "Vah Naboris", "Story", "Heat Resistance", "Yiga"] },
         {"name": "Activate all Towers", "types": ["Tower"] }
     ],
     [
         {"name": "Complete 10 Side Quests", "types": ["Side Quest"] },
         {"name": "Pay all Great Fairies", "types": ["Akkala", "Gerudo", "Rito", "Rupee", "Great Fairy"] },
-        {"name": "Get the Master Sword", "types": ["Woodland", "Korok Forest", "Heart"] },
-        {"name": "Beat Ganon", "types": ["Central","Hyrule Castle", "Ganon"] }
+        {"name": "Beat Ganon", "types": ["Central", "Hyrule Castle", "Ganon"] }
     ]
 ]

--- a/bingo-templates/botw.json
+++ b/bingo-templates/botw.json
@@ -8,22 +8,32 @@
     [
 		{"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss", "Monster"] },
         {"name": "Kill a Wizzrobe", "types": ["Miniboss", "Monster"]},
+        {"name": "Cook a Hearty meal", "types": ["Cooking", "Hearts"] },
+        {"name": "Cook a Hasty meal", "types": ["Cooking", "Speed"] },
+        {"name": "Cook a Spicy meal", "types": ["Cooking", "Cold Resistance"] },
         {"name": "Activate the Dueling Peaks Tower", "types": ["Dueling Peaks", "Tower"] },
-        {"name": "Activate the Faron Tower", "types": ["Lake Hylia", "Faron", "Tower"] }
+		{"name": "Complete 'The Two Rings' Shrine Quest","types":["Ridgeland", "Shrine Quest"]}
     ],
     [
+        {"name": "Cook a Mighty meal", "types": ["Cooking", "Attack"] },
+        {"name": "Cook a Tough meal", "types": ["Cooking", "Defence"] },
         {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko",  "Side Quest"]},
         {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss", "Monster"] },
         {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine"] },
         {"name": "Pay 1 Great Fairy", "types": ["Akkala", "Wasteland", "Tabantha", "Rupee", "Great Fairy"] },
+        {"name": "Activate the Faron Tower", "types": ["Lake Hylia", "Faron", "Tower"] }
     ],
     [
+        {"name": "Cook a Chilly meal", "types": ["Cooking", "Heat Resistance"] },
+        {"name": "Cook an Energizing meal", "types": ["Cooking", "Stamina"] },
+        {"name": "Complete the 'Cliffside Etchings' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Gerudo"] },
         {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "Dueling Peaks", "Kakariko", "Side Quest"] },
         {"name": "Obtain part of the Climbing Gear set", "types": ["Dueling Peaks", "Shrine", "Armor"] },
         {"name": "Activate the Lake Tower", "types": ["Lake", "Tower"] },
         {"name": "Activate the Hateno Tower", "types": ["Hateno", "Tower"] }
     ],
     [
+		{"name": "Complete 'The Cursed Statue' Shrine Quest","types":["Hateno", "Shrine Quest"]},
         {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Lanayru"] },
         {"name": "Activate the Lanayru Tower", "types": ["Lanayru", "Tower"] },
         {"name": "Activate the Wasteland Tower", "types": ["Wasteland", "Tower"] },
@@ -75,14 +85,14 @@
         {"name": "Find 5 Koroks in the Eldin Tower Region", "types": ["Eldin", "Korok"] },
         {"name": "Find 5 Koroks in the Hebra Tower Region", "types": ["Korok", "Hebra", "Cold Resistance"] },
         {"name": "Complete the Vortex Shrine Quest", "types": ["Akkala", "Shrine", "Shrine Quest"] },
-        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Faron", "Shrine Quest", "Shrine"] },
         {"name": "Register the Royal Horse", "types": ["Centeral", "Central Hyrule", "Horse", "Stamina"] }
     ],
     [
 		{"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "Hateno", "Heart", "Stamina"] },
         {"name": "Kill a Walking Guardian", "types": ["Central", "Hyrule Castle", "Guardian"] },
         {"name": "Complete 5 Shrines", "types": ["Shrine"] },
-        {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["Faron", "Hinox", "Monster", "Shrine", "Shrine Quest"] }
+        {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["Faron", "Hinox", "Monster", "Shrine", "Shrine Quest"] },
+        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Faron", "Shrine Quest", "Shrine"] }
     ],
     [
         {"name": "Collect 2 Memories", "types": ["Hateno", "Memory", "Story"] },

--- a/bingo-templates/botw.json
+++ b/bingo-templates/botw.json
@@ -1,1188 +1,165 @@
 [
     [
-        {
-            "name": "Obtain 3 Koroks on the Plateau",
-            "types": [
-                "Plateau",
-                "Center",
-                "Inventory",
-                "Korok",
-                "Weapon",
-                "Shield",
-                "Bow",
-                "Beginning Story"
-            ]
-        },
-        {
-            "name": "Open a Bokoblin Camp Chest",
-            "types": [
-                "Plateau",
-                "Center",
-                "Inventory",
-                "Beginning Story"
-            ]
-        },
-        {
-            "name": "Obtain the Warm Doublet",
-            "types": [
-                "Cold Resistance",
-                "Beginning Story",
-                "Armor"
-            ]
-        }
+        {"name": "Obtain 3 Koroks on the Plateau", "types": ["Plateau", "Center", "Inventory", "Korok", "Weapon", "Shield", "Bow", "Beginning Story"] },
+        {"name": "Open a Bokoblin Camp Chest", "types": ["Plateau", "Center", "Inventory", "Beginning Story"] },
+        {"name": "Obtain the Warm Doublet", "types": ["Cold Resistance", "Beginning Story", "Armor"] }
     ],
     [
-        {
-            "name": "Complete the 'Watch Out for the Flowers' Shrine Quest",
-            "types": [
-                "Shrine",
-                "Shrine Quest",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "West Necluda",
-                "Necluda",
-                "East"
-            ]
-        },
-        {
-            "name": "Open 2 Bokoblin Camp Chests",
-            "types": [
-                "Plateau",
-                "Center",
-                "Inventory",
-                "Beginning Story"
-            ]
-        }
+        {"name": "Complete the 'Watch Out for the Flowers' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "West Necluda", "Necluda", "East"] },
+        {"name": "Open 2 Bokoblin Camp Chests", "types": ["Plateau", "Center", "Inventory", "Beginning Story"] }
     ],
     [
-        {
-            "name": "Kill a Stone Talus",
-            "types": [
-                "Rupee",
-                "Miniboss"
-            ]
-        },
-        {
-            "name": "Complete the 'Crowned Beast' Shrine Quest",
-            "types": [
-                "Shrine",
-                "Shrine Quest",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Lanayru",
-                "East"
-            ]
-        },
-        {
-            "name": "Activate the Dueling Peaks Tower",
-            "types": [
-                "West Necluda",
-                "Necluda",
-                "East",
-                "Beginning Story",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Activate the Faron Tower",
-            "types": [
-                "Lake Floria",
-                "Lake Hylia",
-                "Faron",
-                "South",
-                "South East",
-                "Tower"
-            ]
-        }
+        {"name": "Kill a Stone Talus", "types": ["Rupee", "Miniboss"] },
+        {"name": "Complete the 'Crowned Beast' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] },
+        {"name": "Activate the Dueling Peaks Tower", "types": ["West Necluda", "Necluda", "East", "Beginning Story", "Tower"] },
+        {"name": "Activate the Faron Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Tower"] }
     ],
     [
-        {
-            "name": "Pay 1 Great Fairy",
-            "types": [
-                "North",
-                "East",
-                "West",
-                "Akkala",
-                "Gerudo",
-                "Rito",
-                "Necluda",
-                "West Necluda",
-                "Armor Upgrade",
-                "Rupee",
-                "Great Fairy"
-            ]
-        },
-        {
-            "name": "Complete the 'Master of the Wind' Shrine Quest",
-            "types": [
-                "Shrine",
-                "Shrine Quest",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Lanayru",
-                "East"
-            ]
-        }
+        {"name": "Pay 1 Great Fairy", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
+        {"name": "Complete the 'Master of the Wind' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Lanayru", "East"] }
     ],
     [
-        {
-            "name": "Obtain 2 Koroks in the Hateno Region",
-            "types": [
-                "East Necluda",
-                "East",
-                "Hateno",
-                "Inventory",
-                "Korok",
-                "Weapon",
-                "Shield",
-                "Bow",
-                "Beginning Story"
-            ]
-        },
-        {
-            "name": "Collect 5 Korok Seeds",
-            "types": [
-                "Inventory",
-                "Korok",
-                "Weapon",
-                "Shield",
-                "Bow"
-            ]
-        },
-        {
-            "name": "Activate the Lake Tower",
-            "types": [
-                "Lake Floria",
-                "Lake Hylia",
-                "Faron",
-                "South",
-                "East",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Activate the Hateno Tower",
-            "types": [
-                "East Necluda",
-                "East",
-                "Hateno",
-                "Beginning Story",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Activate the Lanayru Tower",
-            "types": [
-                "Zora's Domain",
-                "Lanayru",
-                "East",
-                "Story",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Complete 'The Priceless Maracas' Side Quest",
-            "types": [
-                "Kakariko",
-                "Necluda",
-                "East",
-                "West Necluda",
-                "Beginning Story",
-                "Story",
-            ]
-        },
-        {
-            "name": "Activate the Wasteland Tower",
-            "types": [
-                "Gerudo",
-                "South",
-                "West",
-                "Tower",
-                "Story"
-            ]
-        },
-        {
-            "name": "Activate the Ridgeland Tower",
-            "types": [
-                "Center",
-                "West",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Activate the Central Tower",
-            "types": [
-                "Center",
-                "Central Hyrule",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Kill a Wizzrobe",
-            "types": []
-        },
-        {
-            "name": "Complete a Minor Test of Strength Shrine",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        }
+        {"name": "Obtain 2 Koroks in the Hateno Region", "types": ["East Necluda", "East", "Hateno", "Inventory", "Korok", "Weapon", "Shield", "Bow", "Beginning Story"] },
+        {"name": "Collect 5 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] },
+        {"name": "Activate the Lake Tower", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Tower"] },
+        {"name": "Activate the Hateno Tower", "types": ["East Necluda", "East", "Hateno", "Beginning Story", "Tower"] },
+        {"name": "Activate the Lanayru Tower", "types": ["Zora's Domain", "Lanayru", "East", "Story", "Tower"] },
+        {"name": "Complete 'The Priceless Maracas' Side Quest", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Beginning Story", "Story",]},
+        {"name": "Activate the Wasteland Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
+        {"name": "Activate the Ridgeland Tower", "types": ["Center", "West", "Tower"] },
+        {"name": "Activate the Central Tower", "types": ["Center", "Central Hyrule", "Tower"] },
+        {"name": "Kill a Wizzrobe", "types": []},
+        {"name": "Complete a Minor Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
     ],
     [
-        {
-            "name": "Complete the 'Flown the Coop' Side Quest",
-            "types": [
-                "Impa",
-                "West Necluda",
-                "Kakariko",
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Activate the Woodland Tower",
-            "types": [
-                "Korok Forest",
-                "North",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Activate the Gerudo Tower",
-            "types": [
-                "Gerudo",
-                "South",
-                "West",
-                "Tower",
-                "Story"
-            ]
-        },
-        {
-            "name": "Activate the Akkala Tower",
-            "types": [
-                "North",
-                "East",
-                "Tower"
-            ]
-        },
-        {
-            "name": "Talk to Kilton",
-            "types": [
-                "North",
-                "East",
-                "Monster Part"
-            ]
-        },
-        {
-            "name": "Activate the Eldin Tower",
-            "types": [
-                "North",
-                "East",
-                "Tower",
-                "Story",
-                "Death Mountain"
-            ]
-        },
-        {
-            "name": "Collect 2000 Rupees",
-            "types": [
-                "Rupee"
-            ]
-        },
-        {
-            "name": "Get the Champion's Tunic",
-            "types": [
-                "Kakariko",
-                "Necluda",
-                "East",
-                "West Necluda",
-                "Beginning Story",
-                "Story"
-            ]
-        }
+        {"name": "Complete the 'Flown the Coop' Side Quest", "types": ["Impa", "West Necluda", "Kakariko", "Side Quest"] },
+        {"name": "Activate the Woodland Tower", "types": ["Korok Forest", "North", "Tower"] },
+        {"name": "Activate the Gerudo Tower", "types": ["Gerudo", "South", "West", "Tower", "Story"] },
+        {"name": "Activate the Akkala Tower", "types": ["North", "East", "Tower"] },
+        {"name": "Talk to Kilton", "types": ["North", "East", "Monster Part"] },
+        {"name": "Activate the Eldin Tower", "types": ["North", "East", "Tower", "Story", "Death Mountain"] },
+        {"name": "Collect 2000 Rupees", "types": ["Rupee"] },
+        {"name": "Get the Champion's Tunic", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Beginning Story", "Story"] }
     ],
     [
-        {
-            "name": "Find 5 Koroks in the Dueling Peaks Tower region",
-            "types": [
-                "Korok",
-                "Dueling Peaks",
-                "West Necluda",
-                "Necluda",
-                "East"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Faron Tower Region",
-            "types": [
-                "Lake Floria",
-                "Lake Hylia",
-                "Faron",
-                "South",
-                "South East",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Complete the 'Song of Storms' Shrine Quest",
-            "types": [
-                "Shrine Quest",
-                "South",
-                "Faron",
-                "East Necluda",
-                "Shrine",
-                "Heart",
-                "Stamina",
-                "Thunder"
-            ]
-        },
-        {
-            "name": "Kill a Hinox",
-            "types": [
-                "Rupee",
-                "Miniboss"
-            ]
-        },
-        {
-            "name": "Activate the Hebra Tower",
-            "types": [
-                "North",
-                "West",
-                "Tower",
-                "Story",
-                "Hebra"
-            ]
-        }
+        {"name": "Find 5 Koroks in the Dueling Peaks Tower region", "types": ["Korok", "Dueling Peaks", "West Necluda", "Necluda", "East"] },
+        {"name": "Find 5 Koroks in the Faron Tower Region", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East", "Korok"] },
+        {"name": "Complete the 'Song of Storms' Shrine Quest", "types": ["Shrine Quest", "South", "Faron", "East Necluda", "Shrine", "Heart", "Stamina", "Thunder"] },
+        {"name": "Kill a Hinox", "types": ["Rupee", "Miniboss"] },
+        {"name": "Activate the Hebra Tower", "types": ["North", "West", "Tower", "Story", "Hebra"] }
     ],
     [
-        {
-            "name": "Complete 'The Gut Check Challenge' Shrine Quest",
-            "types": [
-                "Shrine",
-                "Shrine Quest",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Eldin",
-                "North",
-                "East"
-            ]
-        },
-        {
-            "name": "Complete the Forgotten Temple's Shrine",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Hebra",
-                "North",
-                "West"
-            ]
-        },
-        {
-            "name": "Complete the 'Twin Memories' shrines",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "West Necluda",
-                "Necluda",
-                "East"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Lake Tower Region",
-            "types": [
-                "Lake Floria",
-                "Lake Hylia",
-                "Faron",
-                "South",
-                "East",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Hateno Tower Region",
-            "types": [
-                "East Necluda",
-                "East",
-                "Hateno",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Pay 2 Great Fairies",
-            "types": [
-                "North",
-                "East",
-                "West",
-                "Akkala",
-                "Gerudo",
-                "Rito",
-                "Necluda",
-                "West Necluda",
-                "Armor Upgrade",
-                "Rupee",
-                "Great Fairy"
-            ]
-        }
+        {"name": "Complete 'The Gut Check Challenge' Shrine Quest", "types": ["Shrine", "Shrine Quest", "Soul Orb", "Heart", "Stamina", "Eldin", "North", "East"] },
+        {"name": "Complete the Forgotten Temple's Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Hebra", "North", "West"] },
+        {"name": "Complete the 'Twin Memories' shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "West Necluda", "Necluda", "East"] },
+        {"name": "Find 5 Koroks in the Lake Tower Region", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "East", "Korok"] },
+        {"name": "Find 5 Koroks in the Hateno Tower Region", "types": ["East Necluda", "East", "Hateno", "Korok"] },
+        {"name": "Pay 2 Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] }
     ],
     [
-        {
-            "name": "Complete the 'Shrouded Shrine' Shrine Quest",
-            "types": [
-                "Shrine",
-                "Shrine Quest",
-                "North",
-                "Soul Orb",
-                "Heart",
-                "Stamina"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Lanayru Tower Region",
-            "types": [
-                "Zora's Domain",
-                "Lanayru",
-                "East",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Wasteland Tower Region",
-            "types": [
-                "Gerudo",
-                "South",
-                "West",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Ridgeland Tower Region",
-            "types": [
-                "Center",
-                "West",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Get the Sheikah Set",
-            "types": [
-                "Kakariko",
-                "Necluda",
-                "East",
-                "West Necluda",
-                "Armor",
-                "Rupee",
-                "Stealth"
-            ]
-        },
-        {
-            "name": "Get the Soldier Set",
-            "types": [
-                "Hateno",
-                "Necluda",
-                "East",
-                "East Necluda",
-                "Armor",
-                "Rupee"
-            ]
-        }
+        {"name": "Complete the 'Shrouded Shrine' Shrine Quest", "types": ["Shrine", "Shrine Quest", "North", "Soul Orb", "Heart", "Stamina"] },
+        {"name": "Find 5 Koroks in the Lanayru Tower Region", "types": ["Zora's Domain", "Lanayru", "East", "Korok"] },
+        {"name": "Find 5 Koroks in the Wasteland Tower Region", "types": ["Gerudo", "South", "West", "Korok"] },
+        {"name": "Find 5 Koroks in the Ridgeland Tower Region", "types": ["Center", "West", "Korok"] },
+        {"name": "Get the Sheikah Set", "types": ["Kakariko", "Necluda", "East", "West Necluda", "Armor", "Rupee", "Stealth"] },
+        {"name": "Get the Soldier Set", "types": ["Hateno", "Necluda", "East", "East Necluda", "Armor", "Rupee"] }
     ],
     [
-        {
-            "name": "Find 5 Koroks in the Central Tower Region",
-            "types": [
-                "Center",
-                "Central Hyrule",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Woodland Tower Region",
-            "types": [
-                "Korok Forest",
-                "North",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Gerudo Tower Region",
-            "types": [
-                "Gerudo",
-                "South",
-                "West",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Read Zelda's Diary",
-            "types": [
-                "Central Hyrule",
-                "Hyrule Castle",
-                "North",
-                "Story"
-            ]
-        },
-        {
-            "name": "Bake an Apple Pie",
-            "types": [
-                "Rupee"
-            ]
-        },
-        {
-            "name": "Obtain the Hylian Shield",
-            "types": [
-                "Central Hyrule",
-                "Hyrule Castle",
-                "North"
-            ]
-        }
+        {"name": "Find 5 Koroks in the Central Tower Region", "types": ["Center", "Central Hyrule", "Korok"] },
+        {"name": "Find 5 Koroks in the Woodland Tower Region", "types": ["Korok Forest", "North", "Korok"] },
+        {"name": "Find 5 Koroks in the Gerudo Tower Region", "types": ["Gerudo", "South", "West", "Korok"] },
+        {"name": "Read Zelda's Diary", "types": ["Central Hyrule", "Hyrule Castle", "North", "Story"] },
+        {"name": "Bake an Apple Pie", "types": ["Rupee"] },
+        {"name": "Obtain the Hylian Shield", "types": ["Central Hyrule", "Hyrule Castle", "North"] }
     ],
     [
-        {
-            "name": "Find 5 Koroks in the Akkala Tower Region",
-            "types": [
-                "North",
-                "East",
-                "Korok"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Eldin Tower Region",
-            "types": [
-                "North",
-                "East",
-                "Korok",
-                "Death Mountain"
-            ]
-        },
-        {
-            "name": "Find 5 Koroks in the Hebra Tower Region",
-            "types": [
-                "North",
-                "West",
-                "Korok",
-                "Hebra"
-            ]
-        },
-        {
-            "name": "Complete the Vortex Shrine Quest",
-            "types": [
-                "East",
-                "South",
-                "South East",
-                "Faron",
-                "Necluda",
-                "Shrine",
-                "Shrine Quest"
-            ]
-        },
-        {
-            "name": "Complete the 'Stranded on Eventide' Shrine Quest",
-            "types": [
-                "Shrine Quest",
-                "South",
-                "East",
-                "South East",
-                "Shrine",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        },
-        {
-            "name": "Register the Royal Horse",
-            "types": [
-                "Center",
-                "Central Hyrule",
-                "Horse",
-                "Stamina"
-            ]
-        }
+        {"name": "Find 5 Koroks in the Akkala Tower Region", "types": ["North", "East", "Korok"] },
+        {"name": "Find 5 Koroks in the Eldin Tower Region", "types": ["North", "East", "Korok", "Death Mountain"] },
+        {"name": "Find 5 Koroks in the Hebra Tower Region", "types": ["North", "West", "Korok", "Hebra"] },
+        {"name": "Complete the Vortex Shrine Quest", "types": ["East", "South", "South East", "Faron", "Necluda", "Shrine", "Shrine Quest"] },
+        {"name": "Complete the 'Stranded on Eventide' Shrine Quest", "types": ["Shrine Quest", "South", "East", "South East", "Shrine", "Heart", "Stamina", "Ancient Item"] },
+        {"name": "Register the Royal Horse", "types": ["Center", "Central Hyrule", "Horse", "Stamina"] }
     ],
     [
-	{
-            "name": "Complete 'The Statue's Bargain' Side Quest",
-            "types": [
-                "Side Quest",
-                "East Necluda",
-                "Hateno",
-                "Heart",
-                "Stamina"
-            ]
-        },
-        {
-            "name": "Kill a Walking Guardian",
-            "types": [
-                "Central Hyrule",
-                "Hyrule Castle",
-                "Ancient Item",
-                "Center",
-                "North",
-                "Guardian"
-            ]
-        },
-        {
-            "name": "Complete 5 Shrines",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        },
-        {
-            "name": "Complete the 'Three Giant Brothers' Shrine Quest",
-            "types": [
-                "East",
-                "South",
-                "South East",
-                "Faron",
-                "Necluda",
-                "Shrine",
-                "Shrine Quest"
-            ]
-        }
+		{"name": "Complete 'The Statue's Bargain' Side Quest", "types": ["Side Quest", "East Necluda", "Hateno", "Heart", "Stamina"] },
+        {"name": "Kill a Walking Guardian", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] },
+        {"name": "Complete 5 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
+        {"name": "Complete the 'Three Giant Brothers' Shrine Quest", "types": ["East", "South", "South East", "Faron", "Necluda", "Shrine", "Shrine Quest"] }
     ],
     [
-        {
-            "name": "Collect 2 Memories",
-            "types": [
-                "Memory",
-                "Story"
-            ]
-        },
-        {
-            "name": "Obtain a Material from Naydra",
-            "types": [
-                "Necluda",
-                "Mount Lanayru",
-                "East Necluda",
-                "East"
-            ]
-        },
-        {
-            "name": "Take a Selfie with Sidon",
-            "types": [
-                "East",
-                "Zora's Domain",
-                "Armor",
-                "Divine Beast",
-                "Story",
-                "Camera",
-                "Hateno",
-                "Beginning Story"
-            ]
-        },
-        {
-            "name": "Finish a Korok Trial",
-            "types": [
-                "Korok Forest",
-                "North",
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina"
-            ]
-        }
+        {"name": "Collect 2 Memories", "types": ["Memory", "Story"] },
+        {"name": "Obtain a Material from Naydra", "types": ["Necluda", "Mount Lanayru", "East Necluda", "East"] },
+        {"name": "Take a Selfie with Sidon", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story", "Camera", "Hateno", "Beginning Story"] },
+        {"name": "Finish a Korok Trial", "types": ["Korok Forest", "North", "Shrine", "Soul Orb", "Heart", "Stamina"] }
     ],
     [
-        {
-            "name": "Complete the 'Guardian Slideshow' Shrine Quest",
-            "types": [
-                "Shrine Quest",
-                "South",
-                "Shrine",
-                "Heart",
-                "Stamina",
-                "Camera"
-            ]
-        },
-        {
-            "name": "Obtain a Material from Farosh",
-            "types": [
-                "Lake Floria",
-                "Lake Hylia",
-                "Faron",
-                "South",
-                "South East"
-            ]
-        },
-        {
-            "name": "Obtain a Material from Dinraal",
-            "types": [
-                "North",
-                "West",
-                "North West"
-            ]
-        },
-        {
-            "name": "Complete a Modest Test of Strength Shrine",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        }
+        {"name": "Complete the 'Guardian Slideshow' Shrine Quest", "types": ["Shrine Quest", "South", "Shrine", "Heart", "Stamina", "Camera"] },
+        {"name": "Obtain a Material from Farosh", "types": ["Lake Floria", "Lake Hylia", "Faron", "South", "South East"] },
+        {"name": "Obtain a Material from Dinraal", "types": ["North", "West", "North West"] },
+        {"name": "Complete a Modest Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
     ],
     [
-        {
-            "name": "Complete the Shield Surfing minigame",
-            "types": [
-                "Minigame",
-                "North",
-                "West",
-                "Hebra"
-            ]
-        },
-        {
-            "name": "Complete the Bowling minigame",
-            "types": [
-                "Minigame",
-                "North",
-                "West",
-                "Hebra"
-            ]
-        },
-        {
-            "name": "Activate 4 Towers",
-            "types": [
-                "Tower"
-            ]
-        },
-        {
-            "name": "Collect 20 Korok Seeds",
-            "types": [
-                "Inventory",
-                "Korok",
-                "Weapon",
-                "Shield",
-                "Bow"
-            ]
-        }
+        {"name": "Complete the Shield Surfing minigame", "types": ["Minigame", "North", "West", "Hebra"] },
+        {"name": "Complete the Bowling minigame", "types": ["Minigame", "North", "West", "Hebra"] },
+        {"name": "Activate 4 Towers", "types": ["Tower"] },
+        {"name": "Collect 20 Korok Seeds", "types": ["Inventory", "Korok", "Weapon", "Shield", "Bow"] }
     ],
     [
-	{
-            "name": "Complete the 'Robbie's Research' Side Quest",
-            "types": [
-                "Side Quest",
-                "Akkala",
-                "Hateno"
-            ]
-        },
-        {
-            "name": "Upgrade All Runes",
-            "types": [
-                "Side Quest",
-                "Upgrade",
-                "Ancient Item",
-                "Beginning Story",
-                "Necluda",
-                "East Necluda",
-                "Hateno",
-                "East"
-            ]
-        },
-        {
-            "name": "Register the Giant Horse",
-            "types": [
-                "South",
-                "West",
-                "South West",
-                "Horse",
-                "Stamina"
-            ]
-        },
-        {
-            "name": "Get the Zora Set",
-            "types": [
-                "East",
-                "Zora's Domain",
-                "Armor",
-                "Divine Beast",
-                "Story"
-            ]
-        },
-        {
-            "name": "Get the Flamebreaker Set",
-            "types": [
-                "Death Mountain",
-                "Divine Beast",
-                "Vah Rudania",
-                "Heart",
-                "North",
-                "East",
-                "Story",
-                "Armor",
-                "Rupee",
-                "Fire Resistance"
-            ]
-        }
+		{"name": "Complete the 'Robbie's Research' Side Quest", "types": ["Side Quest", "Akkala", "Hateno"] },
+        {"name": "Upgrade All Runes", "types": ["Side Quest", "Upgrade", "Ancient Item", "Beginning Story", "Necluda", "East Necluda", "Hateno", "East"] },
+        {"name": "Register the Giant Horse", "types": ["South", "West", "South West", "Horse", "Stamina"] },
+        {"name": "Get the Zora Set", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story"] },
+        {"name": "Get the Flamebreaker Set", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Heart", "North", "East", "Story", "Armor", "Rupee", "Fire Resistance"] }
     ],
     [
-        {
-            "name": "Mount the Lord of the Mountain",
-            "types": [
-                "Center",
-                "Central Hyrule",
-                "Horse",
-                "Stamina"
-            ]
-        },
-        {
-            "name": "Get the Barbarian Set",
-            "types": [
-                "Shrine",
-                "Hebra",
-                "North",
-                "East",
-                "West",
-                "South",
-                "North East",
-                "North West",
-                "South West",
-                "Armor",
-                "Akkala",
-                "Gerudo"
-            ]
-        },
-        {
-            "name": "Obtain 3 Heart Containers",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Divine Beast"
-            ]
-        },
-        {
-            "name": "Get the Rubber Set",
-            "types": [
-                "East",
-                "Zora's Domain",
-                "Armor",
-                "Divine Beast",
-                "Story"
-            ]
-        }
+        {"name": "Mount the Lord of the Mountain", "types": ["Center", "Central Hyrule", "Horse", "Stamina"] },
+        {"name": "Get the Barbarian Set", "types": ["Shrine", "Hebra", "North", "East", "West", "South", "North East", "North West", "South West", "Armor", "Akkala", "Gerudo"] },
+        {"name": "Obtain 3 Heart Containers", "types": ["Shrine", "Soul Orb", "Heart", "Divine Beast"] },
+        {"name": "Get the Rubber Set", "types": ["East", "Zora's Domain", "Armor", "Divine Beast", "Story"] }
     ],
     [
-        {
-            "name": "Complete 'Little Sister's Big Request' Side Quest",
-            "types": [
-                "Akkala",
-                "Eldin",
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Complete the 'Fragmented Monument' Shrine Quest",
-            "types": [
-                "Shrine Quest",
-                "South",
-                "Faron",
-                "East Necluda",
-                "Shrine",
-                "Heart",
-                "Stamina",
-                "Thunder"
-            ]
-        },
-        {
-            "name": "Complete 'Rushroom Rush' Side Quest",
-            "types": [
-                "Gerudo",
-                "South",
-                "West",
-                "Rushroom",
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Complete 10 Shrines",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        }
+        {"name": "Complete 'Little Sister's Big Request' Side Quest", "types": ["Akkala", "Eldin", "Side Quest"] },
+        {"name": "Complete the 'Fragmented Monument' Shrine Quest", "types": ["Shrine Quest", "South", "Faron", "East Necluda", "Shrine", "Heart", "Stamina", "Thunder"] },
+        {"name": "Complete 'Rushroom Rush' Side Quest", "types": ["Gerudo", "South", "West", "Rushroom", "Side Quest"] },
+        {"name": "Complete 10 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
     ],
     [
-	{
-            "name": "Complete 'The Stolen Heirloom' Shrine Quest",
-            "types": [
-                "Shrine Quest",
-                "West Necluda",
-                "Kakariko",
-                "Shrine"
-            ]
-        },
-        {
-            "name": "Collect 4 Memories",
-            "types": [
-                "Memory",
-                "Story"
-            ]
-        },
-        {
-            "name": "Fill out 20 creatures in the Compendium",
-            "types": [
-                "Camera",
-                "Compendium",
-                "Story"
-            ]
-        },
-        {
-            "name": "Complete 3 Side Quests",
-            "types": [
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Kill Coliseum Lynel",
-            "types": [
-                "Center",
-                "Central Hyrule",
-                "Coliseum",
-                "Lynel",
-                "Miniboss"
-            ]
-        }
+		{"name": "Complete 'The Stolen Heirloom' Shrine Quest", "types": ["Shrine Quest", "West Necluda", "Kakariko", "Shrine"] },
+        {"name": "Collect 4 Memories", "types": ["Memory", "Story"] },
+        {"name": "Fill out 20 creatures in the Compendium", "types": ["Camera", "Compendium", "Story"] },
+        {"name": "Complete 3 Side Quests", "types": ["Side Quest"] },
+        {"name": "Kill Coliseum Lynel", "types": ["Center", "Central Hyrule", "Coliseum", "Lynel", "Miniboss"] }
     ],
     [
-        {
-            "name": "Complete 'Leviathan Bones' Side Quest",
-            "types": [
-                "Gerudo",
-                "Hebra",
-                "Eldin",
-                "Camera",
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Fill out 20 monsters in the Compendium",
-            "types": [
-                "Camera",
-                "Compendium",
-                "Story"
-            ]
-        },
-        {
-            "name": "Fill out 20 equipment in the Compendium",
-            "types": [
-                "Camera",
-                "Compendium",
-                "Story"
-            ]
-        },
-        {
-            "name": "Complete 5 Side Quests",
-            "types": [
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Complete a Major Test of Strength Shrine",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        }
+        {"name": "Complete 'Leviathan Bones' Side Quest", "types": ["Gerudo", "Hebra", "Eldin", "Camera", "Side Quest"] },
+        {"name": "Fill out 20 monsters in the Compendium", "types": ["Camera", "Compendium", "Story"] },
+        {"name": "Fill out 20 equipment in the Compendium", "types": ["Camera", "Compendium", "Story"] },
+        {"name": "Complete 5 Side Quests", "types": ["Side Quest"] },
+        {"name": "Complete a Major Test of Strength Shrine", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] }
     ],
     [
-        {
-            "name": "Buy the Bokoblin Mask from Kilton",
-            "types": [
-                "Monster Part"
-            ]
-        },
-        {
-            "name": "Complete 15 Shrines",
-            "types": [
-                "Shrine",
-                "Soul Orb",
-                "Heart",
-                "Stamina",
-                "Ancient Item"
-            ]
-        },
-        {
-            "name": "Kill 10 Guardians",
-            "types": [
-                "Central Hyrule",
-                "Hyrule Castle",
-                "Ancient Item",
-                "Center",
-                "North",
-                "Guardian"
-            ]
-        }
+        {"name": "Buy the Bokoblin Mask from Kilton", "types": ["Monster Part"] },
+        {"name": "Complete 15 Shrines", "types": ["Shrine", "Soul Orb", "Heart", "Stamina", "Ancient Item"] },
+        {"name": "Kill 10 Guardians", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] }
     ],
     [
-        {
-            "name": "Pay 3 Great Fairies",
-            "types": [
-                "North",
-                "East",
-                "West",
-                "Akkala",
-                "Gerudo",
-                "Rito",
-                "Necluda",
-                "West Necluda",
-                "Armor Upgrade",
-                "Rupee",
-                "Great Fairy"
-            ]
-        },
-        {
-            "name": "Free a Divine Beast",
-            "types": [
-                "Divine Beast",
-                "Story",
-                "Heart"
-            ]
-        }
+        {"name": "Pay 3 Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
+        {"name": "Free a Divine Beast", "types": ["Divine Beast", "Story", "Heart"] }
     ],
     [
-        {
-            "name": "Free Vah Medoh",
-            "types": [
-                "Rito",
-                "Divine Beast",
-                "Vah Medoh",
-                "Heart",
-                "North",
-                "West",
-                "North West",
-                "Story",
-                "Armor",
-                "Cold Resistance",
-                "Hebra"
-            ]
-        },
-        {
-            "name": "Free Vah Ruta",
-            "types": [
-                "Zora's Domain",
-                "Lanayru",
-                "Divine Beast",
-                "Vah Ruta",
-                "Heart",
-                "East",
-                "Story",
-                "Armor",
-                "Swim Speed",
-                "Arrow"
-            ]
-        }
+        {"name": "Free Vah Medoh", "types": ["Rito", "Divine Beast", "Vah Medoh", "Heart", "North", "West", "North West", "Story", "Armor", "Cold Resistance", "Hebra"] },
+        {"name": "Free Vah Ruta", "types": ["Zora's Domain", "Lanayru", "Divine Beast", "Vah Ruta", "Heart", "East", "Story", "Armor", "Swim Speed", "Arrow"] }
     ],
     [
-        {
-            "name": "Free Vah Rudania",
-            "types": [
-                "Death Mountain",
-                "Divine Beast",
-                "Vah Rudania",
-                "Heart",
-                "North",
-                "East",
-                "Story",
-                "Armor",
-                "Fire Resistance"
-            ]
-        },
-        {
-            "name": "Free Vah Naboris",
-            "types": [
-                "Gerudo",
-                "Divine Beast",
-                "Vah Naboris",
-                "Heart",
-                "South",
-                "West",
-                "South West",
-                "Story",
-                "Armor",
-                "Heat Resistance",
-                "Banana",
-                "Yiga"
-            ]
-        },
-        {
-            "name": "Kill 20 Walking Guardians",
-            "types": [
-                "Central Hyrule",
-                "Hyrule Castle",
-                "Ancient Item",
-                "Center",
-                "North",
-                "Guardian"
-            ]
-        },
-        {
-            "name": "Activate all Towers",
-            "types": [
-                "Tower"
-            ]
-        }
+        {"name": "Free Vah Rudania", "types": ["Death Mountain", "Divine Beast", "Vah Rudania", "Heart", "North", "East", "Story", "Armor", "Fire Resistance"] },
+        {"name": "Free Vah Naboris", "types": ["Gerudo", "Divine Beast", "Vah Naboris", "Heart", "South", "West", "South West", "Story", "Armor", "Heat Resistance", "Banana", "Yiga"] },
+        {"name": "Kill 20 Walking Guardians", "types": ["Central Hyrule", "Hyrule Castle", "Ancient Item", "Center", "North", "Guardian"] },
+        {"name": "Activate all Towers", "types": ["Tower"] }
     ],
     [
-        {
-            "name": "Complete 10 Side Quests",
-            "types": [
-                "Side Quest"
-            ]
-        },
-        {
-            "name": "Pay all Great Fairies",
-            "types": [
-                "North",
-                "East",
-                "West",
-                "Akkala",
-                "Gerudo",
-                "Rito",
-                "Necluda",
-                "West Necluda",
-                "Armor Upgrade",
-                "Rupee",
-                "Great Fairy"
-            ]
-        },
-        {
-            "name": "Get the Master Sword",
-            "types": [
-                "Korok Forest",
-                "North",
-                "Heart"
-            ]
-        },
-        {
-            "name": "Beat Ganon",
-            "types": [
-                "Hyrule Castle",
-                "Ganon",
-                "North"
-            ]
-        }
+        {"name": "Complete 10 Side Quests", "types": ["Side Quest"] },
+        {"name": "Pay all Great Fairies", "types": ["North", "East", "West", "Akkala", "Gerudo", "Rito", "Necluda", "West Necluda", "Armor Upgrade", "Rupee", "Great Fairy"] },
+        {"name": "Get the Master Sword", "types": ["Korok Forest", "North", "Heart"] },
+        {"name": "Beat Ganon", "types": ["Hyrule Castle", "Ganon", "North"] }
     ]
 ]


### PR DESCRIPTION
-Removing all the whitespace for easier view of large scale editing
-Remove/rename types. Too many types heavily weights a lot of cards from appearing at all. Instead of cardinal directions or general areas, switching to tower region names.
-Balancing position of cards
-adding new cards, new shrine/side quests, cooking